### PR TITLE
Update UI Extension Config File for Block Progress Capability

### DIFF
--- a/extensions/resident-id/shopify.ui.extension.toml
+++ b/extensions/resident-id/shopify.ui.extension.toml
@@ -6,6 +6,10 @@ extension_points = [
  'Checkout::Dynamic::Render'
 ]
 
+ [capabilities]
+# network_access = true
+ block_progress = true
+
 # [[metafields]]
 # namespace = "my-namespace"
 # key = "my-key"

--- a/extensions/resident-id/src/index.jsx
+++ b/extensions/resident-id/src/index.jsx
@@ -1,14 +1,21 @@
-import React, { useState } from 'react';
-import { render, TextField, useMetafield, useApplyMetafieldsChange, useBuyerJourneyIntercept } from '@shopify/checkout-ui-extensions-react';
-render('Checkout::Dynamic::Render', () => <App />);
+import React from "react";
+import {
+  render,
+  TextField,
+  useApplyMetafieldsChange,
+  useBuyerJourneyIntercept,
+  useMetafield,
+} from "@shopify/checkout-ui-extensions-react";
+import { useState } from "react";
+
+render("Checkout::Dynamic::Render", () => <App />);
 
 function App() {
+  const METAFIELD_NAMESPACE = "RESIDENT_ID_APP";
+  const METAFIELD_KEY = "resident_id";
+
   const [error, setError] = useState(false);
   const updateMetafield = useApplyMetafieldsChange();
-
-  const METAFIELD_NAMESPACE = 'RESIDENT_ID_APP';
-  const METAFIELD_KEY = 'resident_id';
-
   const residentIdState = useMetafield({
     namespace: METAFIELD_NAMESPACE,
     key: METAFIELD_KEY,
@@ -17,24 +24,24 @@ function App() {
   useBuyerJourneyIntercept(() => {
     if (!validateResidentId(residentIdState.value)) {
       return {
-        behavior: 'block',
-        reason: 'Form is not valid.',
+        behavior: "block",
+        reason: "Form is not valid.",
         // if a partner tries block checkout, then `perform()` does not get called and nothing happens
-        // acts like `behavior: allow` 
-        perform: () => showValidationUI()
-      }
+        // acts like `behavior: allow`
+        perform: () => showValidationUI(),
+      };
     } else {
       setError(false);
       return {
-        behavior: 'allow',
-      }
+        behavior: "allow",
+      };
     }
   });
 
   const showValidationUI = () => {
-    console.log('validation UI');
+    console.log("validation UI");
     setError(true);
-  }
+  };
 
   const handleFieldChange = (value) => {
     if (error) {
@@ -43,29 +50,25 @@ function App() {
         setError(false);
       }
     }
-    updateMetafield(
-      {
-        type: 'updateMetafield',
-        namespace: METAFIELD_NAMESPACE,
-        key: METAFIELD_KEY,
-        valueType: 'string',
-        value: value
-      }
-    );
+    updateMetafield({
+      type: "updateMetafield",
+      namespace: METAFIELD_NAMESPACE,
+      key: METAFIELD_KEY,
+      valueType: "string",
+      value: value,
+    });
   };
-
 
   const validateResidentId = (value) => {
     return value.length === 9;
-  }
+  };
 
   return (
     <TextField
-      label='Resident ID'
+      label="Resident ID"
       value={residentIdState?.value}
-      error={error ? 'Please provide a valid ID' : false}
+      error={error ? "Please provide a valid ID" : false}
       onChange={handleFieldChange}
     />
   );
-
 }


### PR DESCRIPTION
* Now to use the `useBuyerJourneyIntercept` hook, and block the progress of the checkout you must set the capability in the `shopify.ui.extension.toml` file.
* [Documentation found here](https://shopify.dev/api/checkout-extensions/checkout/configuration)